### PR TITLE
Add support for object type attributes

### DIFF
--- a/packages/core/src/types/ModelAttribute.ts
+++ b/packages/core/src/types/ModelAttribute.ts
@@ -55,6 +55,14 @@ export type NumberModelAttribute = BaseModelAttribute & {
   default?: number
 }
 
+export type ObjectModelAttribute = BaseModelAttribute & {
+  type: 'object'
+  fields: {
+    [key: string]: ModelAttribute
+  }
+  default?: object
+}
+
 export type RefModelAttribute = BaseModelAttribute & {
   type: 'ref'
   entity: string
@@ -100,6 +108,7 @@ export type ModelAttribute =
   ListModelAttribute |
   MapModelAttribute |
   NumberModelAttribute |
+  ObjectModelAttribute |
   RefModelAttribute |
   SlugModelAttribute |
   StringModelAttribute |

--- a/packages/graphql/test/SchemaBuilder.test.ts
+++ b/packages/graphql/test/SchemaBuilder.test.ts
@@ -17,37 +17,63 @@ describe('SchemaBuilder', () => {
 
     it('should convert boolean to GraphQL type', async () => {
       const config = createEntityConfig({ type: 'boolean' })
-      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type')).toEqual(GraphQLBoolean)
+      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x))
+        .toEqual(GraphQLBoolean)
     })
 
     it('should convert email to GraphQL type', async () => {
       const config = createEntityConfig({ type: 'email' })
-      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type')).toEqual(GraphQLString)
+      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x))
+        .toEqual(GraphQLString)
     })
 
     it('should convert slug to GraphQL type', async () => {
       const config = createEntityConfig({ type: 'slug', setFrom: 'test' })
-      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type')).toEqual(GraphQLString)
+      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x))
+        .toEqual(GraphQLString)
     })
 
     it('should convert string to GraphQL type', async () => {
       const config = createEntityConfig({ type: 'string' })
-      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type')).toEqual(GraphQLString)
+      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x))
+        .toEqual(GraphQLString)
     })
 
     it('should convert date to GraphQL type', async () => {
       const config = createEntityConfig({ type: 'date' })
-      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type')).toEqual(GraphQLDate)
+      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x))
+        .toEqual(GraphQLDate)
     })
 
     it('should convert id to GraphQL type', async () => {
       const config = createEntityConfig({ type: 'id' })
-      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type')).toEqual(GraphQLID)
+      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x))
+        .toEqual(GraphQLID)
     })
 
     it('should convert numbers to GraphQL type', async () => {
       const config = createEntityConfig({ type: 'number' })
-      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type')).toEqual(GraphQLFloat)
+      expect(getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x))
+        .toEqual(GraphQLFloat)
+    })
+
+    it('should convert lists to GraphQL type', async () => {
+      const config = createEntityConfig({ type: 'list', listType: { type: 'string' } })
+      expect(
+        getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x).toString())
+        .toEqual('[String]')
+    })
+
+    it('should convert objects to GraphQL type', async () => {
+      const config = createEntityConfig({
+        type: 'object', fields: {
+          a: { type: 'string' },
+          b: { type: 'number' },
+        },
+      })
+      expect(
+        getAttributeGraphQLType(config, 'key', config.attributes.key, 'type', x => x).toString())
+        .toEqual('Key')
     })
   })
 })


### PR DESCRIPTION
API and GraphQL support for object type attributes.
These are not supported on the dashboard yet, but they can be used in the JSON definition of an entity.

Example:

```json
{
  "field": {
    "type": "object",
    "fields": {
      "subfield1": {
        "type": "boolean",
        "default": true
      },
      "subfield2": {
        "type": "number",
        "max": 100,
        "required": true
      }
    }
  }
}
```