### PR TITLE
Implement eval attribute and refactor model attributes getter

### DIFF
--- a/packages/core/src/controllers/EntityController.ts
+++ b/packages/core/src/controllers/EntityController.ts
@@ -258,9 +258,22 @@ export class EntityController<T extends EntityModel> {
       const settingUser = attribute!.type === 'user' && action === 'create'
 
       if ((validPermissions && shouldSetValue) || settingUser) {
-        model[key as keyof T] = await getModelAttribute(attribute!, key, req.body, req.auth?.id, action === 'update')
+        model[key as keyof T] = await getModelAttribute({
+          entityName: this.entityName,
+          attribute: attribute!,
+          key: key,
+          data: req.body,
+          userId: req.auth?.id,
+          ignoreDefault: action === 'update'
+        })
       } else if (attribute!.default !== undefined && action === 'create') {
-        model[key as keyof T] = await getModelAttribute(attribute!, key, {}, req.auth?.id)
+        model[key as keyof T] = await getModelAttribute({
+          entityName: this.entityName,
+          attribute: attribute!,
+          key: key,
+          data: {},
+          userId: req.auth?.id
+        })
       }
     }
     return model

--- a/packages/core/src/types/ModelAttribute.ts
+++ b/packages/core/src/types/ModelAttribute.ts
@@ -31,6 +31,11 @@ export type EnumModelAttribute = BaseModelAttribute & {
   default?: JsonPrimitive
 }
 
+export type EvalModelAttribute = BaseModelAttribute & {
+  type: 'eval'
+  eval: string
+}
+
 export type IdModelAttribute = BaseModelAttribute & {
   type: 'id'
   permissions?: EntityActionPermissions
@@ -104,6 +109,7 @@ export type ModelAttribute =
   DateModelAttribute |
   EmailModelAttribute |
   EnumModelAttribute |
+  EvalModelAttribute |
   IdModelAttribute |
   ListModelAttribute |
   MapModelAttribute |

--- a/packages/core/test/entity/modelAttributes.test.ts
+++ b/packages/core/test/entity/modelAttributes.test.ts
@@ -1,4 +1,4 @@
-import { Commun, getModelAttribute, parseModelAttribute } from '../../src'
+import { Commun, EntityModel, getModelAttribute, parseModelAttribute } from '../../src'
 import { SecurityUtils } from '../../src/utils'
 import { ObjectId } from 'mongodb'
 import { closeTestApp, startTestApp, stopTestApp } from '@commun/test-utils'
@@ -7,388 +7,839 @@ describe('modelAttributes', () => {
   const entityName = 'modelAttributes'
   const collectionName = entityName
 
-  beforeAll(async () => await startTestApp(Commun))
+  interface TestEntity extends EntityModel {
+    key?: string
+    foo?: string
+    bar?: string
+    num?: number
+  }
+
+  beforeAll(async () => {
+    Commun.registerEntity<TestEntity>({
+      config: {
+        entityName,
+        collectionName,
+        attributes: {
+          key: {
+            type: 'string'
+          },
+          foo: {
+            type: 'string'
+          },
+          bar: {
+            type: 'string'
+          },
+          num: {
+            type: 'number'
+          },
+        }
+      }
+    })
+    await startTestApp(Commun)
+  })
   afterEach(async () => await stopTestApp(collectionName))
   afterAll(closeTestApp)
 
   describe('Boolean', () => {
     it('should return true for a truly value', async () => {
-      expect(await getModelAttribute({ type: 'boolean' }, 'key', { key: 'true' })).toBe(true)
-      expect(await getModelAttribute({ type: 'boolean' }, 'key', { key: true })).toBe(true)
-      expect(await getModelAttribute({ type: 'boolean' }, 'key', {})).toBe(undefined)
-      expect(await getModelAttribute({ type: 'boolean' }, 'key', { key: null })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: { key: 'true' }
+      })).toBe(true)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: { key: true }
+      })).toBe(true)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: {}
+      })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: { key: null }
+      })).toBe(undefined)
     })
 
     it('should return false for a falsy value', async () => {
-      expect(await getModelAttribute({ type: 'boolean' }, 'key', { key: 'false' })).toBe(false)
-      expect(await getModelAttribute({ type: 'boolean' }, 'key', { key: false })).toBe(false)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: { key: 'false' }
+      })).toBe(false)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: { key: false }
+      })).toBe(false)
     })
 
     it('should handle the required attribute', async () => {
-      expect(await getModelAttribute({ type: 'boolean', required: true }, 'key', { key: 'true' })).toBe(true)
-      expect(await getModelAttribute({ type: 'boolean', required: true }, 'key', { key: true })).toBe(true)
-      expect(await getModelAttribute({ type: 'boolean', required: true }, 'key', { key: 'false' })).toBe(false)
-      expect(await getModelAttribute({ type: 'boolean', required: true }, 'key', { key: false })).toBe(false)
-      await expect(getModelAttribute({ type: 'boolean', required: true }, 'key', {}))
-        .rejects.toThrow('key is required')
-      await expect(getModelAttribute({ type: 'boolean', required: true }, 'key', { key: null }))
-        .rejects.toThrow('key is required')
+      expect(getModelAttribute({
+        attribute: { type: 'boolean', required: true },
+        key: 'key',
+        data: { key: 'true' }
+      })).toBe(true)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean', required: true },
+        key: 'key',
+        data: { key: true }
+      })).toBe(true)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean', required: true },
+        key: 'key',
+        data: { key: 'false' }
+      })).toBe(false)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean', required: true },
+        key: 'key',
+        data: { key: false }
+      })).toBe(false)
+      expect(() => getModelAttribute({
+        attribute: { type: 'boolean', required: true },
+        key: 'key',
+        data: {}
+      })).toThrow('key is required')
+      expect(() => getModelAttribute({
+        attribute: { type: 'boolean', required: true },
+        key: 'key',
+        data: { key: null }
+      })).toThrow('key is required')
     })
 
     it('should handle the default attribute', async () => {
-      expect(await getModelAttribute({ type: 'boolean', default: true }, 'key', {})).toBe(true)
-      expect(await getModelAttribute({ type: 'boolean', default: false }, 'key', {})).toBe(false)
-      expect(await getModelAttribute({ type: 'boolean', default: false }, 'key', { key: true })).toBe(true)
-      expect(await getModelAttribute({ type: 'boolean', default: true }, 'key', { key: false })).toBe(false)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean', default: true },
+        key: 'key',
+        data: {}
+      })).toBe(true)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean', default: false },
+        key: 'key',
+        data: {}
+      })).toBe(false)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean', default: false },
+        key: 'key',
+        data: { key: true }
+      })).toBe(true)
+      expect(getModelAttribute({
+        attribute: { type: 'boolean', default: true },
+        key: 'key',
+        data: { key: false }
+      })).toBe(false)
     })
 
     it('should throw an error if the value is not boolean', async () => {
-      await expect(getModelAttribute({ type: 'boolean' }, 'key', { key: 'str' }))
-        .rejects.toThrow('key must be boolean')
-      await expect(getModelAttribute({ type: 'boolean' }, 'key', { key: 123 }))
-        .rejects.toThrow('key must be boolean')
-      await expect(getModelAttribute({ type: 'boolean' }, 'key', { key: {} }))
-        .rejects.toThrow('key must be boolean')
+      expect(() => getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: { key: 'str' }
+      })).toThrow('key must be boolean')
+      expect(() => getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: { key: 123 }
+      })).toThrow('key must be boolean')
+      expect(() => getModelAttribute({
+        attribute: { type: 'boolean' },
+        key: 'key',
+        data: { key: {} }
+      })).toThrow('key must be boolean')
     })
   })
 
   describe('Date', () => {
     it('should return the given date', async () => {
       const date = new Date()
-      expect(await getModelAttribute({ type: 'date' }, 'key', { key: date })).toEqual(date)
-      expect(await getModelAttribute({ type: 'date' }, 'key', { key: 'Tue Feb 04 2020 UTC' }))
+      expect(getModelAttribute({
+        attribute: { type: 'date' },
+        key: 'key',
+        data: { key: date }
+      })).toEqual(date)
+      expect(getModelAttribute({
+        attribute: { type: 'date' },
+        key: 'key',
+        data: { key: 'Tue Feb 04 2020 UTC' }
+      }))
         .toEqual(new Date('Tue Feb 04 2020 UTC'))
-      expect(await getModelAttribute({ type: 'date' }, 'key', { key: 1580774400000 }))
+      expect(getModelAttribute({
+        attribute: { type: 'date' },
+        key: 'key',
+        data: { key: 1580774400000 }
+      }))
         .toEqual(new Date('Tue Feb 04 2020 UTC'))
-      expect(await getModelAttribute({ type: 'date' }, 'key', { key: '1580774400000' }))
+      expect(getModelAttribute({
+        attribute: { type: 'date' },
+        key: 'key',
+        data: { key: '1580774400000' }
+      }))
         .toEqual(new Date('Tue Feb 04 2020 UTC'))
     })
 
     it('should handle the required attribute', async () => {
       const date = new Date()
-      expect(await getModelAttribute({ type: 'date', required: true }, 'key', { key: date })).toEqual(date)
-      await expect(getModelAttribute({ type: 'date', required: true }, 'key', {}))
-        .rejects.toThrow('key is required')
+      expect(getModelAttribute({
+        attribute: { type: 'date', required: true },
+        key: 'key',
+        data: { key: date }
+      })).toEqual(date)
+      expect(() => getModelAttribute({
+        attribute: { type: 'date', required: true },
+        key: 'key',
+        data: {}
+      })).toThrow('key is required')
     })
 
     it('should handle the default attribute', async () => {
       const date1 = new Date()
       const date2 = new Date()
-      expect(await getModelAttribute({ type: 'date', default: date2 }, 'key', { key: date1 })).toEqual(date1)
-      expect(await getModelAttribute({ type: 'date', default: date2 }, 'key', {})).toEqual(date2)
+      expect(getModelAttribute({
+        attribute: { type: 'date', default: date2 },
+        key: 'key',
+        data: { key: date1 }
+      })).toEqual(date1)
+      expect(getModelAttribute({
+        attribute: { type: 'date', default: date2 },
+        key: 'key',
+        data: {}
+      })).toEqual(date2)
     })
 
     it('should throw an error if the value is not a date', async () => {
-      await expect(getModelAttribute({ type: 'date' }, 'key', { key: 'bad date' }))
-        .rejects.toThrow('key must be a date')
+      expect(() => getModelAttribute({
+        attribute: { type: 'date' },
+        key: 'key',
+        data: { key: 'bad date' }
+      })).toThrow('key must be a date')
     })
   })
 
   describe('Email', () => {
     it('should return the given email', async () => {
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: 'email@example.org' }))
-        .toBe('email@example.org')
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: 'email@s.example.org' }))
-        .toBe('email@s.example.org')
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: 'a.b@example.org' }))
-        .toBe('a.b@example.org')
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: 'a.b@s.example.org' }))
-        .toBe('a.b@s.example.org')
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: '' })).toBe(undefined)
-      expect(await getModelAttribute({ type: 'email' }, 'key', {})).toBe(undefined)
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: null })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: 'email@example.org' }
+      })).toBe('email@example.org')
+      expect(getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: 'email@s.example.org' }
+      })).toBe('email@s.example.org')
+      expect(getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: 'a.b@example.org' }
+      })).toBe('a.b@example.org')
+      expect(await getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: 'a.b@s.example.org' }
+      })).toBe('a.b@s.example.org')
+      expect(getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: '' }
+      })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: {}
+      })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: null }
+      })).toBe(undefined)
     })
 
     it('should return the email trimmed', async () => {
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: 'email@example.org   ' }))
-        .toBe('email@example.org')
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: '   email@example.org' }))
-        .toBe('email@example.org')
-      expect(await getModelAttribute({ type: 'email' }, 'key', { key: '   email@example.org   ' }))
-        .toBe('email@example.org')
+      expect(await getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: 'email@example.org   ' }
+      })).toBe('email@example.org')
+      expect(getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: '   email@example.org' }
+      })).toBe('email@example.org')
+      expect(getModelAttribute({
+        attribute: { type: 'email' },
+        key: 'key',
+        data: { key: '   email@example.org   ' }
+      })).toBe('email@example.org')
     })
 
     it('should handle the required attribute', async () => {
-      expect(await getModelAttribute({ type: 'email', required: true }, 'key', { key: 'email@example.org' }))
-        .toBe('email@example.org')
-      await expect(getModelAttribute({ type: 'email', required: true }, 'key', { key: null }))
-        .rejects.toThrow('key is required')
+      expect(getModelAttribute({
+        attribute: { type: 'email', required: true },
+        key: 'key',
+        data: { key: 'email@example.org' }
+      })).toBe('email@example.org')
+      expect(() => getModelAttribute({
+        attribute: { type: 'email', required: true },
+        key: 'key',
+        data: { key: null }
+      })).toThrow('key is required')
     })
 
     it('should handle the default attribute', async () => {
-      expect(await getModelAttribute({ type: 'email', default: 'email@example.org' }, 'key', {}))
-        .toBe('email@example.org')
-      expect(await getModelAttribute({ type: 'email', default: 'email@example.org' }, 'key', {
-        key: 'test-email@example.org'
+      expect(getModelAttribute({
+        attribute: { type: 'email', default: 'email@example.org' },
+        key: 'key',
+        data: {}
+      })).toBe('email@example.org')
+      expect(getModelAttribute({
+        attribute: { type: 'email', default: 'email@example.org' },
+        key: 'key',
+        data: {
+          key: 'test-email@example.org'
+        }
       })).toBe('test-email@example.org')
     })
 
     it('should throw an error if the email is not valid', async () => {
-      await expect(getModelAttribute({ type: 'email', required: true }, 'key', { key: 'email' }))
-        .rejects.toThrow('key is not a valid email address')
-      await expect(getModelAttribute({ type: 'email', required: true }, 'key', { key: 'email@' }))
-        .rejects.toThrow('key is not a valid email address')
-      await expect(getModelAttribute({ type: 'email', required: true }, 'key', { key: '@example.org' }))
-        .rejects.toThrow('key is not a valid email address')
-      await expect(getModelAttribute({ type: 'email', required: true }, 'key', { key: 'email@@example.org' }))
-        .rejects.toThrow('key is not a valid email address')
+      expect(() => getModelAttribute({
+        attribute: { type: 'email', required: true },
+        key: 'key',
+        data: { key: 'email' }
+      })).toThrow('key is not a valid email address')
+      expect(() => getModelAttribute({
+        attribute: { type: 'email', required: true },
+        key: 'key',
+        data: { key: 'email@' }
+      })).toThrow('key is not a valid email address')
+      expect(() => getModelAttribute({
+        attribute: { type: 'email', required: true },
+        key: 'key',
+        data: { key: '@example.org' }
+      })).toThrow('key is not a valid email address')
+      expect(() => getModelAttribute({
+        attribute: { type: 'email', required: true },
+        key: 'key',
+        data: { key: 'email@@example.org' }
+      })).toThrow('key is not a valid email address')
     })
   })
 
   describe('Enum', () => {
     it('should return the given value', async () => {
-      expect(await getModelAttribute({ type: 'enum', values: [1, 2, 3] }, 'key', { key: 1 })).toBe(1)
-      expect(await getModelAttribute({ type: 'enum', values: [1, 2, 3] }, 'key', { key: 2 })).toBe(2)
-      expect(await getModelAttribute({ type: 'enum', values: [1, 2, 3] }, 'key', { key: 3 })).toBe(3)
+      expect(getModelAttribute({
+        attribute: { type: 'enum', values: [1, 2, 3] },
+        key: 'key',
+        data: { key: 1 }
+      })).toBe(1)
+      expect(getModelAttribute({
+        attribute: { type: 'enum', values: [1, 2, 3] },
+        key: 'key',
+        data: { key: 2 }
+      })).toBe(2)
+      expect(getModelAttribute({
+        attribute: { type: 'enum', values: [1, 2, 3] },
+        key: 'key',
+        data: { key: 3 }
+      })).toBe(3)
     })
 
     it('should throw an error if the given value is not in the enum', async () => {
-      await expect(getModelAttribute({ type: 'enum', values: [1, 2, 3] }, 'key', { key: 4 }))
-        .rejects.toThrow('key must be one of 1, 2, 3')
+      expect(() => getModelAttribute({
+        attribute: { type: 'enum', values: [1, 2, 3] },
+        key: 'key',
+        data: { key: 4 }
+      })).toThrow('key must be one of 1, 2, 3')
     })
 
     it('should handle the required attribute', async () => {
-      expect(await getModelAttribute({ type: 'enum', values: [1, 2, 3], required: true }, 'key', { key: 1 }))
-        .toBe(1)
-      await expect(getModelAttribute({ type: 'enum', values: [1, 2, 3], required: true }, 'key', {}))
-        .rejects.toThrow('key is required')
+      expect(getModelAttribute({
+        attribute: { type: 'enum', values: [1, 2, 3], required: true },
+        key: 'key',
+        data: { key: 1 }
+      })).toBe(1)
+      expect(() => getModelAttribute({
+        attribute: { type: 'enum', values: [1, 2, 3], required: true },
+        key: 'key',
+        data: {}
+      })).toThrow('key is required')
     })
 
     it('should handle the default attribute', async () => {
-      expect(await getModelAttribute({ type: 'enum', values: [1, 2, 3], default: 2 }, 'key', {}))
-        .toBe(2)
-      expect(await getModelAttribute({ type: 'enum', values: [1, 2, 3], default: 2 }, 'key', { key: 1 }))
-        .toBe(1)
+      expect(getModelAttribute({
+        attribute: { type: 'enum', values: [1, 2, 3], default: 2 },
+        key: 'key',
+        data: {}
+      })).toBe(2)
+      expect(getModelAttribute({
+        attribute: { type: 'enum', values: [1, 2, 3], default: 2 },
+        key: 'key',
+        data: { key: 1 }
+      })).toBe(1)
+    })
+  })
+
+  describe('Eval', () => {
+    it('should return the given value', async () => {
+      expect(await getModelAttribute({
+        entityName,
+        attribute: { type: 'eval', eval: 'test' },
+        key: 'key',
+        data: { key: 'test' }
+      })).toBe('test')
+    })
+
+    it('should parse simple math', async () => {
+      expect(await getModelAttribute({
+        entityName,
+        attribute: { type: 'eval', eval: 'Val: {2 + 2}' },
+        key: 'key',
+        data: { key: 'test' }
+      })).toBe('Val: 4')
+      expect(await getModelAttribute({
+        entityName,
+        attribute: { type: 'eval', eval: 'Val: {this.num * 2}' },
+        key: 'key',
+        data: { key: 'test', num: 3 }
+      })).toBe('Val: 6')
+    })
+
+    it('should parse model values', async () => {
+      expect(await getModelAttribute({
+        entityName,
+        attribute: { type: 'eval', eval: '{this.foo}' },
+        key: 'key',
+        data: { key: 'test', foo: 'bar' }
+      })).toBe('bar')
+      expect(await getModelAttribute({
+        entityName,
+        attribute: { type: 'eval', eval: '{this.foo}:{this.bar}' },
+        key: 'key',
+        data: { key: 'test', foo: '1', bar: '2' }
+      })).toBe('1:2')
+    })
+
+    it('should handle the required attribute', async () => {
+      expect(await getModelAttribute({
+        entityName,
+        attribute: { type: 'eval', eval: '{this.key}', required: true },
+        key: 'key',
+        data: { key: 'test' }
+      })).toBe('test')
+      await expect(getModelAttribute({
+        entityName,
+        attribute: { type: 'eval', eval: '{this.key}', required: true },
+        key: 'key',
+        data: { key: '' }
+      })).rejects.toThrow('key is required')
     })
   })
 
   describe('List', () => {
     it('should return the given list parsed to the list type', async () => {
       expect(await getModelAttribute({
-        type: 'list',
-        listType: { type: 'number' }
-      }, 'key', { key: ['1', '2', '3'] })).toEqual([1, 2, 3])
+        attribute: {
+          type: 'list',
+          listType: { type: 'number' }
+        },
+        key: 'key',
+        data: { key: ['1', '2', '3'] }
+      })).toEqual([1, 2, 3])
 
       expect(await getModelAttribute({
-        type: 'list',
-        listType: { type: 'string', maxLength: 3 }
-      }, 'key', { key: ['a', 'b', 'c'] })).toEqual(['a', 'b', 'c'])
+        attribute: {
+          type: 'list',
+          listType: { type: 'string', maxLength: 3 }
+        },
+        key: 'key',
+        data: { key: ['a', 'b', 'c'] }
+      })).toEqual(['a', 'b', 'c'])
     })
 
     it('should throw an error if one of the items of the list does not respect the constraints', async () => {
       await expect(getModelAttribute({
-        type: 'list',
-        listType: { type: 'string', maxLength: 3 }
-      }, 'key', { key: ['a', 'b', 'long-string'] })).rejects.toThrow(/key index 2 must be shorter than 3 characters/)
+        attribute: {
+          type: 'list',
+          listType: { type: 'string', maxLength: 3 }
+        },
+        key: 'key',
+        data: { key: ['a', 'b', 'long-string'] }
+      })).rejects.toThrow(/key index 2 must be shorter than 3 characters/)
 
       await expect(getModelAttribute({
-        type: 'list',
-        listType: { type: 'email' }
-      }, 'key', { key: ['not an email'] })).rejects.toThrow(/key index 0 is not a valid email address/)
+        attribute: {
+          type: 'list',
+          listType: { type: 'email' }
+        },
+        key: 'key',
+        data: { key: ['not an email'] }
+      })).rejects.toThrow(/key index 0 is not a valid email address/)
     })
 
     it('should handle the maxItems attribute', async () => {
       expect(await getModelAttribute({
-        type: 'list',
-        maxItems: 3,
-        listType: { type: 'number' }
-      }, 'key', { key: [1, 2, 3] })).toEqual([1, 2, 3])
+        attribute: {
+          type: 'list',
+          maxItems: 3,
+          listType: { type: 'number' }
+        },
+        key: 'key',
+        data: { key: [1, 2, 3] }
+      })).toEqual([1, 2, 3])
 
-      await expect(getModelAttribute({
-        type: 'list',
-        maxItems: 3,
-        listType: { type: 'number' }
-      }, 'key', { key: [1, 2, 3, 4, 5] })).rejects.toThrow(/key can contain up to 3 items/)
+      expect(() => getModelAttribute({
+        attribute: {
+          type: 'list',
+          maxItems: 3,
+          listType: { type: 'number' }
+        },
+        key: 'key',
+        data: { key: [1, 2, 3, 4, 5] }
+      })).toThrow(/key can contain up to 3 items/)
     })
 
     it('should handle the required attribute', async () => {
       expect(await getModelAttribute({
-        type: 'list',
-        required: true,
-        listType: { type: 'number' }
-      }, 'key', { key: [1, 2, 3] })).toEqual([1, 2, 3])
+        attribute: {
+          type: 'list',
+          required: true,
+          listType: { type: 'number' }
+        },
+        key: 'key',
+        data: { key: [1, 2, 3] }
+      })).toEqual([1, 2, 3])
 
-      await expect(getModelAttribute({
-        type: 'list',
-        required: true,
-        listType: { type: 'number' }
-      }, 'key', {})).rejects.toThrow(/key is required/)
+      expect(() => getModelAttribute({
+        attribute: {
+          type: 'list',
+          required: true,
+          listType: { type: 'number' }
+        },
+        key: 'key',
+        data: {}
+      })).toThrow(/key is required/)
     })
 
     it('should handle the default attribute', async () => {
       expect(await getModelAttribute({
-        type: 'list',
-        default: [9, 8, 7],
-        listType: { type: 'number' }
-      }, 'key', { key: [1, 2, 3] })).toEqual([1, 2, 3])
+        attribute: {
+          type: 'list',
+          default: [9, 8, 7],
+          listType: { type: 'number' }
+        },
+        key: 'key',
+        data: { key: [1, 2, 3] }
+      })).toEqual([1, 2, 3])
 
       expect(await getModelAttribute({
-        type: 'list',
-        default: [9, 8, 7],
-        listType: { type: 'number' }
-      }, 'key', {})).toEqual([9, 8, 7])
+        attribute: {
+          type: 'list',
+          default: [9, 8, 7],
+          listType: { type: 'number' }
+        },
+        key: 'key',
+        data: {}
+      })).toEqual([9, 8, 7])
     })
 
     it('should throw an error if the value is not an array', async () => {
-      await expect(getModelAttribute({
-        type: 'list',
-        listType: { type: 'number' }
-      }, 'key', { key: 'not an array' })).rejects.toThrow(/key must be an array/)
+      expect(() => getModelAttribute({
+        attribute: {
+          type: 'list',
+          listType: { type: 'number' }
+        },
+        key: 'key',
+        data: { key: 'not an array' }
+      })).toThrow(/key must be an array/)
     })
   })
 
   describe('Map', () => {
     it('should return the given map with key and value parsed', async () => {
       expect(await getModelAttribute({
-        type: 'map',
-        keyType: { type: 'string' },
-        valueType: { type: 'number' },
-      }, 'key', { key: { a: '1', b: '2' } })).toEqual({ a: 1, b: 2 })
+        attribute: {
+          type: 'map',
+          keyType: { type: 'string' },
+          valueType: { type: 'number' },
+        },
+        key: 'key',
+        data: { key: { a: '1', b: '2' } }
+      })).toEqual({ a: 1, b: 2 })
 
       expect(await getModelAttribute({
-        type: 'map',
-        keyType: { type: 'string' },
-        valueType: { type: 'string', maxLength: 3 },
-      }, 'key', { key: { a: '1', b: '2' } })).toEqual({ a: '1', b: '2' })
+        attribute: {
+          type: 'map',
+          keyType: { type: 'string' },
+          valueType: { type: 'string', maxLength: 3 },
+        },
+        key: 'key',
+        data: { key: { a: '1', b: '2' } }
+      })).toEqual({ a: '1', b: '2' })
     })
 
     it('should throw an error if a key of the map does not respect a constrain', async () => {
       await expect(getModelAttribute({
-        type: 'map',
-        keyType: { type: 'string', maxLength: 3 },
-        valueType: { type: 'number' },
-      }, 'map', { map: { abcd: '1' } })).rejects.toThrow(/map key must be shorter than 3 characters/)
+        attribute: {
+          type: 'map',
+          keyType: { type: 'string', maxLength: 3 },
+          valueType: { type: 'number' },
+        },
+        key: 'map',
+        data: { map: { abcd: '1' } }
+      })).rejects.toThrow(/map key must be shorter than 3 characters/)
     })
 
     it('should throw an error if a value of the map does not respect a constrain', async () => {
       await expect(getModelAttribute({
-        type: 'map',
-        keyType: { type: 'string' },
-        valueType: { type: 'number', max: 5 },
-      }, 'map', { map: { a: 1, b: 6 } })).rejects.toThrow(/map b must be smaller or equal than 5/)
+        attribute: {
+          type: 'map',
+          keyType: { type: 'string' },
+          valueType: { type: 'number', max: 5 },
+        },
+        key: 'map',
+        data: { map: { a: 1, b: 6 } }
+      })).rejects.toThrow(/map b must be smaller or equal than 5/)
 
       expect(await getModelAttribute({
-        type: 'map',
-        keyType: { type: 'enum', values: ['a', 'b'] },
-        valueType: { type: 'number' },
-      }, 'map', { map: { a: 1, b: 2 } })).toEqual({ a: 1, b: 2 })
+        attribute: {
+          type: 'map',
+          keyType: { type: 'enum', values: ['a', 'b'] },
+          valueType: { type: 'number' },
+        },
+        key: 'map',
+        data: { map: { a: 1, b: 2 } }
+      })).toEqual({ a: 1, b: 2 })
 
       await expect(getModelAttribute({
-        type: 'map',
-        keyType: { type: 'enum', values: ['a', 'b'] },
-        valueType: { type: 'number' },
-      }, 'map', { map: { a: 1, c: 2 } })).rejects.toThrow(/map key must be one of a, b/)
+        attribute: {
+          type: 'map',
+          keyType: { type: 'enum', values: ['a', 'b'] },
+          valueType: { type: 'number' },
+        },
+        key: 'map',
+        data: { map: { a: 1, c: 2 } }
+      })).rejects.toThrow(/map key must be one of a, b/)
     })
 
     it('should support map o maps', async () => {
       expect(await getModelAttribute({
-        type: 'map',
-        keyType: { type: 'string' },
-        valueType: { type: 'map', keyType: { type: 'string' }, valueType: { type: 'number' } },
-      }, 'key', { key: { a: { b: '1' }, c: { d: '2' } } })).toEqual({ a: { b: 1 }, c: { d: 2 } })
+        attribute: {
+          type: 'map',
+          keyType: { type: 'string' },
+          valueType: { type: 'map', keyType: { type: 'string' }, valueType: { type: 'number' } },
+        },
+        key: 'key',
+        data: { key: { a: { b: '1' }, c: { d: '2' } } }
+      })).toEqual({ a: { b: 1 }, c: { d: 2 } })
     })
 
     it('should handle the required attribute', async () => {
       expect(await getModelAttribute({
-        type: 'map',
-        required: true,
-        keyType: { type: 'string' },
-        valueType: { type: 'number' },
-      }, 'key', { key: { a: '1', b: '2' } })).toEqual({ a: 1, b: 2 })
+        attribute: {
+          type: 'map',
+          required: true,
+          keyType: { type: 'string' },
+          valueType: { type: 'number' },
+        },
+        key: 'key',
+        data: { key: { a: '1', b: '2' } }
+      })).toEqual({ a: 1, b: 2 })
 
-      await expect(getModelAttribute({
-        type: 'map',
-        required: true,
-        keyType: { type: 'string' },
-        valueType: { type: 'number' },
-      }, 'key', {})).rejects.toThrow(/key is required/)
+      expect(() => getModelAttribute({
+        attribute: {
+          type: 'map',
+          required: true,
+          keyType: { type: 'string' },
+          valueType: { type: 'number' },
+        },
+        key: 'key',
+        data: {}
+      })).toThrow(/key is required/)
     })
 
     it('should handle the default attribute', async () => {
       expect(await getModelAttribute({
-        type: 'map',
-        default: { z: 1, x: 2 },
-        keyType: { type: 'string' },
-        valueType: { type: 'number' },
-      }, 'key', { key: { a: '1', b: '2' } })).toEqual({ a: 1, b: 2 })
+        attribute: {
+          type: 'map',
+          default: { z: 1, x: 2 },
+          keyType: { type: 'string' },
+          valueType: { type: 'number' },
+        },
+        key: 'key',
+        data: { key: { a: '1', b: '2' } }
+      })).toEqual({ a: 1, b: 2 })
 
       expect(await getModelAttribute({
-        type: 'map',
-        default: { z: 1, x: 2 },
-        keyType: { type: 'string' },
-        valueType: { type: 'number' },
-      }, 'key', {})).toEqual({ z: 1, x: 2 })
+        attribute: {
+          type: 'map',
+          default: { z: 1, x: 2 },
+          keyType: { type: 'string' },
+          valueType: { type: 'number' },
+        },
+        key: 'key',
+        data: {}
+      })).toEqual({ z: 1, x: 2 })
     })
 
     it('should throw an error if the value is not a map', async () => {
-      await expect(getModelAttribute({
-        type: 'map',
-        keyType: { type: 'string' },
-        valueType: { type: 'number' },
-      }, 'key', { key: 123 })).rejects.toThrow(/key must be an object/)
+      expect(() => getModelAttribute({
+        attribute: {
+          type: 'map',
+          keyType: { type: 'string' },
+          valueType: { type: 'number' },
+        },
+        key: 'key',
+        data: { key: 123 }
+      })).toThrow(/key must be an object/)
     })
   })
 
   describe('Number', () => {
     it('should return the given number', async () => {
-      expect(await getModelAttribute({ type: 'number' }, 'key', { key: 123 })).toBe(123)
-      expect(await getModelAttribute({ type: 'number' }, 'key', { key: '123' })).toBe(123)
-      expect(await getModelAttribute({ type: 'number' }, 'key', { key: 0 })).toBe(0)
-      expect(await getModelAttribute({ type: 'number' }, 'key', { key: .5 })).toBe(.5)
-      expect(await getModelAttribute({ type: 'number' }, 'key', { key: '.5' })).toBe(.5)
-      expect(await getModelAttribute({ type: 'number' }, 'key', { key: '0.5' })).toBe(.5)
-      expect(await getModelAttribute({ type: 'number' }, 'key', {})).toBe(undefined)
-      expect(await getModelAttribute({ type: 'number' }, 'key', { key: null })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'number' },
+        key: 'key',
+        data: { key: 123 }
+      })).toBe(123)
+      expect(getModelAttribute({
+        attribute: { type: 'number' },
+        key: 'key',
+        data: { key: '123' }
+      })).toBe(123)
+      expect(getModelAttribute({
+        attribute: { type: 'number' },
+        key: 'key',
+        data: { key: 0 }
+      })).toBe(0)
+      expect(getModelAttribute({
+        attribute: { type: 'number' },
+        key: 'key',
+        data: { key: .5 }
+      })).toBe(.5)
+      expect(getModelAttribute({
+        attribute: { type: 'number' },
+        key: 'key',
+        data: { key: '.5' }
+      })).toBe(.5)
+      expect(getModelAttribute({
+        attribute: { type: 'number' },
+        key: 'key',
+        data: { key: '0.5' }
+      })).toBe(.5)
+      expect(getModelAttribute({
+        attribute: { type: 'number' },
+        key: 'key',
+        data: {}
+      })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'number' },
+        key: 'key',
+        data: { key: null }
+      })).toBe(undefined)
     })
 
     it('should handle the max attribute', async () => {
-      expect(await getModelAttribute({ type: 'number', max: 100 }, 'key', { key: 100 })).toBe(100)
-      await expect(getModelAttribute({ type: 'number', max: 100 }, 'key', { key: 101 }))
-        .rejects.toThrow('key must be smaller or equal than 100')
+      expect(getModelAttribute({
+        attribute: { type: 'number', max: 100 },
+        key: 'key',
+        data: { key: 100 }
+      })).toBe(100)
+      expect(() => getModelAttribute({
+        attribute: { type: 'number', max: 100 },
+        key: 'key',
+        data: { key: 101 }
+      })).toThrow('key must be smaller or equal than 100')
     })
 
     it('should handle then min attribute', async () => {
-      expect(await getModelAttribute({ type: 'number', min: 100 }, 'key', { key: 100 })).toBe(100)
-      await expect(getModelAttribute({ type: 'number', min: 100 }, 'key', { key: 99 }))
-        .rejects.toThrow('key must be larger or equal than 100')
+      expect(getModelAttribute({
+        attribute: { type: 'number', min: 100 },
+        key: 'key',
+        data: { key: 100 }
+      })).toBe(100)
+      expect(() => getModelAttribute({
+        attribute: { type: 'number', min: 100 },
+        key: 'key',
+        data: { key: 99 }
+      })).toThrow('key must be larger or equal than 100')
     })
 
     it('should handle the required attribute', async () => {
-      expect(await getModelAttribute({ type: 'number', required: true }, 'key', { key: 0 })).toBe(0)
-      expect(await getModelAttribute({ type: 'number', required: true }, 'key', { key: '0' })).toBe(0)
-      await expect(getModelAttribute({ type: 'number', required: true }, 'key', {}))
-        .rejects.toThrow('key is required')
-      await expect(getModelAttribute({ type: 'number', required: true }, 'key', { key: null }))
-        .rejects.toThrow('key is required')
+      expect(getModelAttribute({
+        attribute: { type: 'number', required: true },
+        key: 'key',
+        data: { key: 0 }
+      })).toBe(0)
+      expect(getModelAttribute({
+        attribute: { type: 'number', required: true },
+        key: 'key',
+        data: { key: '0' }
+      })).toBe(0)
+      expect(() => getModelAttribute({
+        attribute: { type: 'number', required: true },
+        key: 'key',
+        data: {}
+      })).toThrow('key is required')
+      expect(() => getModelAttribute({
+        attribute: { type: 'number', required: true },
+        key: 'key',
+        data: { key: null }
+      })).toThrow('key is required')
     })
 
     it('should handle the default attribute', async () => {
-      expect(await getModelAttribute({ type: 'number', default: 123 }, 'key', {})).toBe(123)
-      expect(await getModelAttribute({ type: 'number', default: 123 }, 'key', { key: 987 })).toBe(987)
+      expect(getModelAttribute({
+        attribute: { type: 'number', default: 123 },
+        key: 'key',
+        data: {}
+      })).toBe(123)
+      expect(getModelAttribute({
+        attribute: { type: 'number', default: 123 },
+        key: 'key',
+        data: { key: 987 }
+      })).toBe(987)
     })
 
     it('should throw an error if the value is not a number', async () => {
-      await expect(getModelAttribute({ type: 'number', required: true }, 'key', { key: 'wrong' }))
-        .rejects.toThrow('key must be a number')
-      await expect(getModelAttribute({ type: 'number', required: true }, 'key', { key: true }))
-        .rejects.toThrow('key must be a number')
-      await expect(getModelAttribute({ type: 'number', required: true }, 'key', { key: false }))
-        .rejects.toThrow('key must be a number')
-      await expect(getModelAttribute({ type: 'number', required: true }, 'key', { key: {} }))
-        .rejects.toThrow('key must be a number')
+      expect(() => getModelAttribute({
+        attribute: { type: 'number', required: true },
+        key: 'key',
+        data: { key: 'wrong' }
+      })).toThrow('key must be a number')
+      expect(() => getModelAttribute({
+        attribute: { type: 'number', required: true },
+        key: 'key',
+        data: { key: true }
+      })).toThrow('key must be a number')
+      expect(() => getModelAttribute({
+        attribute: { type: 'number', required: true },
+        key: 'key',
+        data: { key: false }
+      })).toThrow('key must be a number')
+      expect(() => getModelAttribute({
+        attribute: { type: 'number', required: true },
+        key: 'key',
+        data: { key: {} }
+      })).toThrow('key must be a number')
     })
   })
 
   describe('Object', () => {
     it('should return the given object with all elements parsed', async () => {
       expect(await getModelAttribute({
-        type: 'object',
-        fields: {
-          a: { type: 'string' },
-          b: { type: 'boolean' },
-          c: { type: 'number' },
+        attribute: {
+          type: 'object',
+          fields: {
+            a: { type: 'string' },
+            b: { type: 'boolean' },
+            c: { type: 'number' },
+          },
         },
-      }, 'key', { key: { a: 'test', b: 'true', c: '123' } })).toEqual({
+        key: 'key',
+        data: { key: { a: 'test', b: 'true', c: '123' } }
+      })).toEqual({
         a: 'test',
         b: true,
         c: 123,
@@ -397,62 +848,89 @@ describe('modelAttributes', () => {
 
     it('should throw an error if onefield does not respect the constraints', async () => {
       expect(await getModelAttribute({
-        type: 'object',
-        fields: {
-          a: { type: 'string' },
-          b: { type: 'boolean' },
-          c: { type: 'number', max: 10 },
+        attribute: {
+          type: 'object',
+          fields: {
+            a: { type: 'string' },
+            b: { type: 'boolean' },
+            c: { type: 'number', max: 10 },
+          },
         },
-      }, 'key', { key: { a: 'test', b: 'true', c: '10' } })).toEqual({
+        key: 'key',
+        data: { key: { a: 'test', b: 'true', c: '10' } }
+      })).toEqual({
         a: 'test',
         b: true,
         c: 10,
       })
 
       await expect(getModelAttribute({
-        type: 'object',
-        fields: {
-          a: { type: 'string' },
-          b: { type: 'boolean' },
-          c: { type: 'number', max: 10 },
+        attribute: {
+          type: 'object',
+          fields: {
+            a: { type: 'string' },
+            b: { type: 'boolean' },
+            c: { type: 'number', max: 10 },
+          },
         },
-      }, 'key', { key: { a: 'test', b: 'true', c: '11' } }))
-        .rejects.toThrow('c must be smaller or equal than 10')
+        key: 'key',
+        data: { key: { a: 'test', b: 'true', c: '11' } }
+      })).rejects.toThrow('c must be smaller or equal than 10')
     })
 
     it('should handle the required attribute', async () => {
       expect(await getModelAttribute({
-        type: 'object',
-        required: true,
-        fields: { a: { type: 'string' }, },
-      }, 'key', { key: { a: 'test' } })).toEqual({ a: 'test' })
+        attribute: {
+          type: 'object',
+          required: true,
+          fields: { a: { type: 'string' }, },
+        },
+        key: 'key',
+        data: { key: { a: 'test' } }
+      })).toEqual({ a: 'test' })
 
       await expect(getModelAttribute({
-        type: 'object',
-        required: true,
-        fields: { a: { type: 'string' }, },
-      }, 'key', {})).rejects.toThrow(/key is required/)
+        attribute: {
+          type: 'object',
+          required: true,
+          fields: { a: { type: 'string' }, },
+        },
+        key: 'key',
+        data: {}
+      })).rejects.toThrow(/key is required/)
     })
 
     it('should handle the default attribute', async () => {
       expect(await getModelAttribute({
-        type: 'object',
-        fields: { a: { type: 'string' }, },
-        default: { a: 'default' },
-      }, 'key', { key: { a: 'test' } })).toEqual({ a: 'test' })
+        attribute: {
+          type: 'object',
+          fields: { a: { type: 'string' }, },
+          default: { a: 'default' },
+        },
+        key: 'key',
+        data: { key: { a: 'test' } }
+      })).toEqual({ a: 'test' })
 
       expect(await getModelAttribute({
-        type: 'object',
-        fields: { a: { type: 'string' }, },
-        default: { a: 'default' },
-      }, 'key', {})).toEqual({ a: 'default' })
+        attribute: {
+          type: 'object',
+          fields: { a: { type: 'string' }, },
+          default: { a: 'default' },
+        },
+        key: 'key',
+        data: {}
+      })).toEqual({ a: 'default' })
     })
 
     it('should throw an error if the value is not an object', async () => {
       await expect(getModelAttribute({
-        type: 'object',
-        fields: { a: { type: 'string' }, },
-      }, 'key', { key: 'not an object' })).rejects.toThrow(/key must be an object/)
+        attribute: {
+          type: 'object',
+          fields: { a: { type: 'string' }, },
+        },
+        key: 'key',
+        data: { key: 'not an object' }
+      })).rejects.toThrow(/key must be an object/)
     })
   })
 
@@ -472,44 +950,69 @@ describe('modelAttributes', () => {
     })
 
     it('should return an ObjectId with the referenced value', async () => {
-      const res = await getModelAttribute({ type: 'ref', entity: entityName }, 'item', { item: itemId })
+      const res = await getModelAttribute({
+        attribute: { type: 'ref', entity: entityName },
+        key: 'item',
+        data: { item: itemId }
+      })
       expect(res instanceof ObjectId).toBe(true)
       expect(res.toString()).toBe(itemId)
     })
 
     it('should throw an error if value is not a valid ObjectId', async () => {
-      await expect(getModelAttribute({ type: 'ref', entity: entityName }, 'item', { item: 'bad-id' }))
-        .rejects.toThrow('item is not a valid ID')
+      await expect(getModelAttribute({
+        attribute: { type: 'ref', entity: entityName },
+        key: 'item',
+        data: { item: 'bad-id' }
+      })).rejects.toThrow('item is not a valid ID')
     })
 
     it('should throw an error if the value does not reference to an existent resource', async () => {
       const objectId = new ObjectId()
-      await expect(getModelAttribute({ type: 'ref', entity: entityName }, 'item', { item: objectId.toString() }))
-        .rejects.toThrow('item not found')
+      await expect(getModelAttribute({
+        attribute: { type: 'ref', entity: entityName },
+        key: 'item',
+        data: { item: objectId.toString() }
+      })).rejects.toThrow('item not found')
     })
 
     it('should handle the required attribute', async () => {
       const res = await getModelAttribute({
-        type: 'ref',
-        entity: entityName,
-        required: true
-      }, 'item', { item: itemId })
+        attribute: {
+          type: 'ref',
+          entity: entityName,
+          required: true
+        },
+        key: 'item',
+        data: { item: itemId }
+      })
       expect(res instanceof ObjectId).toBe(true)
       expect(res.toString()).toBe(itemId)
 
-      await expect(getModelAttribute({ type: 'ref', entity: entityName, required: true }, 'item', {}))
-        .rejects.toThrow('item is required')
+      await expect(getModelAttribute({
+        attribute: { type: 'ref', entity: entityName, required: true },
+        key: 'item',
+        data: {}
+      })).rejects.toThrow('item is required')
     })
 
     it('should handle the default attribute', async () => {
-      const res = await getModelAttribute({ type: 'ref', entity: entityName, default: itemId }, 'item', {})
+      const res = await getModelAttribute({
+        attribute: { type: 'ref', entity: entityName, default: itemId },
+        key: 'item',
+        data: {}
+      })
       expect(res instanceof ObjectId).toBe(true)
       expect(res.toString()).toBe(itemId)
       const res2 = await getModelAttribute({
-        type: 'ref',
-        entity: entityName,
-        default: new ObjectId().toString()
-      }, 'item', { item: itemId })
+        attribute: {
+          type: 'ref',
+          entity: entityName,
+          default: new ObjectId().toString()
+        },
+        key: 'item',
+        data: { item: itemId }
+      })
       expect(res2 instanceof ObjectId).toBe(true)
       expect(res2.toString()).toBe(itemId)
     })
@@ -521,100 +1024,225 @@ describe('modelAttributes', () => {
     })
 
     it('should return a slug string from the target', async () => {
-      expect(await getModelAttribute({ type: 'slug', setFrom: 'title' }, 'key', { title: 'Test Title', key: '' }))
-        .toBe('test-title')
-      expect(await getModelAttribute({ type: 'slug', setFrom: 'title' }, 'key', { title: '  TEST  ', key: '' }))
-        .toBe('test')
-      expect(await getModelAttribute({ type: 'slug', setFrom: 'title' }, 'key',
-        { title: 'This is   @1   title?!', key: '' })
+      expect(getModelAttribute({
+        attribute: { type: 'slug', setFrom: 'title' },
+        key: 'key',
+        data: {
+          title: 'Test Title',
+          key: ''
+        }
+      })).toBe('test-title')
+      expect(getModelAttribute({
+        attribute: { type: 'slug', setFrom: 'title' },
+        key: 'key',
+        data: {
+          title: '  TEST  ',
+          key: ''
+        }
+      })).toBe('test')
+      expect(getModelAttribute({
+          attribute: { type: 'slug', setFrom: 'title' },
+          key: 'key',
+          data: {
+            title: 'This is   @1   title?!',
+            key: ''
+          }
+        })
       ).toBe('this-is-1-title')
-      expect(await getModelAttribute({ type: 'slug', setFrom: 'title' }, 'key', {
-        title: '---$ Test Title $---',
-        key: ''
-      }))
-        .toBe('test-title')
+      expect(getModelAttribute({
+        attribute: { type: 'slug', setFrom: 'title' },
+        key: 'key',
+        data: {
+          title: '---$ Test Title $---',
+          key: ''
+        }
+      })).toBe('test-title')
     })
 
     it('should handle the prefix attribute', async () => {
-      expect(await getModelAttribute({
-        type: 'slug',
-        setFrom: 'title',
-        prefix: { type: 'random', chars: 8 }
-      }, 'key', { title: 'test', key: '' })).toBe('RANDOM:8-test')
+      expect(getModelAttribute({
+        attribute: {
+          type: 'slug',
+          setFrom: 'title',
+          prefix: { type: 'random', chars: 8 }
+        },
+        key: 'key',
+        data: {
+          title: 'test',
+          key: ''
+        }
+      })).toBe('RANDOM:8-test')
     })
 
     it('should handle the suffix attribute', async () => {
-      expect(await getModelAttribute({
-        type: 'slug',
-        setFrom: 'title',
-        suffix: { type: 'random', chars: 8 }
-      }, 'key', { title: 'test', key: '' })).toBe('test-RANDOM:8')
+      expect(getModelAttribute({
+        attribute: {
+          type: 'slug',
+          setFrom: 'title',
+          suffix: { type: 'random', chars: 8 }
+        },
+        key: 'key',
+        data: {
+          title: 'test',
+          key: ''
+        }
+      })).toBe('test-RANDOM:8')
     })
 
     it('should handle the required attribute', async () => {
-      expect(await getModelAttribute({ type: 'slug', setFrom: 'title', required: true }, 'key', {
-        title: 'test',
-        key: ''
+      expect(getModelAttribute({
+        attribute: { type: 'slug', setFrom: 'title', required: true },
+        key: 'key',
+        data: {
+          title: 'test',
+          key: ''
+        }
       })).toBe('test')
-      await expect(getModelAttribute({ type: 'slug', setFrom: 'title', required: true }, 'key', {
-        title: '',
-        key: ''
-      })).rejects.toThrow('key is required')
+      expect(() => getModelAttribute({
+        attribute: { type: 'slug', setFrom: 'title', required: true },
+        key: 'key',
+        data: {
+          title: '',
+          key: ''
+        }
+      })).toThrow('key is required')
     })
 
     it('should handle the default attribute', async () => {
-      expect(await getModelAttribute({ type: 'slug', setFrom: 'title', default: 'default' }, 'key', {}))
-        .toBe('default')
-      expect(await getModelAttribute({ type: 'slug', setFrom: 'title', default: 'default' }, 'key', {
-        title: 'test',
-        key: ''
+      expect(getModelAttribute({
+        attribute: { type: 'slug', setFrom: 'title', default: 'default' },
+        key: 'key',
+        data: {}
+      })).toBe('default')
+      expect(getModelAttribute({
+        attribute: { type: 'slug', setFrom: 'title', default: 'default' },
+        key: 'key',
+        data: {
+          title: 'test',
+          key: ''
+        }
       })).toBe('test')
     })
   })
 
   describe('String', () => {
     it('should return the given string', async () => {
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: 'test' })).toBe('test')
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: '123' })).toBe('123')
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: 123 })).toBe('123')
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: 0 })).toBe('0')
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: true })).toBe('true')
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: false })).toBe('false')
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: '' })).toBe('')
-      expect(await getModelAttribute({ type: 'string' }, 'key', {})).toBe(undefined)
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: null })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: 'test' }
+      })).toBe('test')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: '123' }
+      })).toBe('123')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: 123 }
+      })).toBe('123')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: 0 }
+      })).toBe('0')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: true }
+      })).toBe('true')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: false }
+      })).toBe('false')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: '' }
+      })).toBe('')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: {}
+      })).toBe(undefined)
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: null }
+      })).toBe(undefined)
     })
 
     it('should return the given string trimmed', async () => {
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: 'test  ' })).toBe('test')
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: '  test' })).toBe('test')
-      expect(await getModelAttribute({ type: 'string' }, 'key', { key: '  test  ' })).toBe('test')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: 'test  ' }
+      })).toBe('test')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: '  test' }
+      })).toBe('test')
+      expect(getModelAttribute({
+        attribute: { type: 'string' },
+        key: 'key',
+        data: { key: '  test  ' }
+      })).toBe('test')
     })
 
     it('should handle the maxLength attribute', async () => {
-      expect(await getModelAttribute({ type: 'string', maxLength: 4 }, 'key', { key: 'test' }))
-        .toBe('test')
-      expect(await getModelAttribute({ type: 'string', maxLength: 4 }, 'key', { key: 'test    ' }))
-        .toBe('test')
-      await expect(getModelAttribute({ type: 'string', maxLength: 3 }, 'key', { key: 'test' }))
-        .rejects.toThrow('key must be shorter than 3 characters')
+      expect(getModelAttribute({
+        attribute: { type: 'string', maxLength: 4 },
+        key: 'key',
+        data: { key: 'test' }
+      })).toBe('test')
+      expect(getModelAttribute({
+        attribute: { type: 'string', maxLength: 4 },
+        key: 'key',
+        data: { key: 'test    ' }
+      })).toBe('test')
+      expect(() => getModelAttribute({
+        attribute: { type: 'string', maxLength: 3 },
+        key: 'key',
+        data: { key: 'test' }
+      })).toThrow('key must be shorter than 3 characters')
     })
 
     it('should handle the validRegex attribute', async () => {
-      expect(await getModelAttribute({ type: 'string', validRegex: '^[a-z]*$' }, 'key', { key: 'test' }))
-        .toBe('test')
-      await expect(getModelAttribute({ type: 'string', validRegex: '^[a-z]*$' }, 'key', { key: 'Test' }))
-        .rejects.toThrow('key contains invalid characters')
+      expect(getModelAttribute({
+        attribute: { type: 'string', validRegex: '^[a-z]*$' },
+        key: 'key',
+        data: { key: 'test' }
+      })).toBe('test')
+      expect(() => getModelAttribute({
+        attribute: { type: 'string', validRegex: '^[a-z]*$' },
+        key: 'key',
+        data: { key: 'Test' }
+      })).toThrow('key contains invalid characters')
 
-      expect(await getModelAttribute({ type: 'string', validRegex: '^[a-zA-Z]*$' }, 'key', { key: 'Test' }))
-        .toBe('Test')
-      await expect(getModelAttribute({ type: 'string', validRegex: '^[a-zA-Z]*$' }, 'key', { key: 'Test 1' }))
-        .rejects.toThrow('key contains invalid characters')
+      expect(getModelAttribute({
+        attribute: { type: 'string', validRegex: '^[a-zA-Z]*$' },
+        key: 'key',
+        data: { key: 'Test' }
+      })).toBe('Test')
+      expect(() => getModelAttribute({
+        attribute: { type: 'string', validRegex: '^[a-zA-Z]*$' },
+        key: 'key',
+        data: { key: 'Test 1' }
+      })).toThrow('key contains invalid characters')
 
-      expect(await getModelAttribute({ type: 'string', validRegex: '^[a-z0-9\\s]*$' }, 'key', { key: 'test 123' }))
-        .toBe('test 123')
-      await expect(getModelAttribute({ type: 'string', validRegex: '^[a-z0-9\\s]*$' }, 'key', { key: 'test @1' }))
-        .rejects.toThrow('key contains invalid characters')
+      expect(getModelAttribute({
+        attribute: { type: 'string', validRegex: '^[a-z0-9\\s]*$' },
+        key: 'key',
+        data: { key: 'test 123' }
+      })).toBe('test 123')
+      expect(() => getModelAttribute({
+        attribute: { type: 'string', validRegex: '^[a-z0-9\\s]*$' },
+        key: 'key',
+        data: { key: 'test @1' }
+      })).toThrow('key contains invalid characters')
     })
 
     it('should handle the hash attribute', async () => {
@@ -622,28 +1250,59 @@ describe('modelAttributes', () => {
         .fn(async (str: string, saltRounds: number) => `hashed_${str}_${saltRounds}`)
 
       expect(await getModelAttribute({
-        type: 'string',
-        hash: { algorithm: 'bcrypt', salt_rounds: 12 }
-      }, 'key', { key: 'test' }))
-        .toBe('hashed_test_12')
+        attribute: {
+          type: 'string',
+          hash: { algorithm: 'bcrypt', salt_rounds: 12 }
+        },
+        key: 'key',
+        data: { key: 'test' }
+      })).toBe('hashed_test_12')
     })
 
     it('should handle the required attribute', async () => {
-      expect(await getModelAttribute({ type: 'string', required: true }, 'key', { key: 'test' })).toBe('test')
-      expect(await getModelAttribute({ type: 'string', required: true }, 'key', { key: 0 })).toBe('0')
-      await expect(getModelAttribute({ type: 'string', required: true }, 'key', { key: '' }))
-        .rejects.toThrow('key is required')
-      await expect(getModelAttribute({ type: 'string', required: true }, 'key', { key: null }))
-        .rejects.toThrow('key is required')
-      await expect(getModelAttribute({ type: 'string', required: true }, 'key', {}))
-        .rejects.toThrow('key is required')
-      await expect(getModelAttribute({ type: 'string', required: true }, 'key', { key: '    ' }))
-        .rejects.toThrow('key is required')
+      expect(getModelAttribute({
+        attribute: { type: 'string', required: true },
+        key: 'key',
+        data: { key: 'test' }
+      })).toBe('test')
+      expect(getModelAttribute({
+        attribute: { type: 'string', required: true },
+        key: 'key',
+        data: { key: 0 }
+      })).toBe('0')
+      expect(() => getModelAttribute({
+        attribute: { type: 'string', required: true },
+        key: 'key',
+        data: { key: '' }
+      })).toThrow('key is required')
+      expect(() => getModelAttribute({
+        attribute: { type: 'string', required: true },
+        key: 'key',
+        data: { key: null }
+      })).toThrow('key is required')
+      expect(() => getModelAttribute({
+        attribute: { type: 'string', required: true },
+        key: 'key',
+        data: {}
+      })).toThrow('key is required')
+      expect(() => getModelAttribute({
+        attribute: { type: 'string', required: true },
+        key: 'key',
+        data: { key: '    ' }
+      })).toThrow('key is required')
     })
 
     it('should handle the default attribute', async () => {
-      expect(await getModelAttribute({ type: 'string', default: 'test' }, 'key', {})).toBe('test')
-      expect(await getModelAttribute({ type: 'string', default: 'test' }, 'key', { key: 'aaa' })).toBe('aaa')
+      expect(getModelAttribute({
+        attribute: { type: 'string', default: 'test' },
+        key: 'key',
+        data: {}
+      })).toBe('test')
+      expect(getModelAttribute({
+        attribute: { type: 'string', default: 'test' },
+        key: 'key',
+        data: { key: 'aaa' }
+      })).toBe('aaa')
     })
   })
 
@@ -651,25 +1310,48 @@ describe('modelAttributes', () => {
     const userId = new ObjectId()
 
     it('should return an ObjectId with the user id or undefined', async () => {
-      expect(await getModelAttribute({ type: 'user' }, 'key', {}, userId.toString()))
-        .toEqual(userId)
-      expect(await getModelAttribute({ type: 'user' }, 'key', {})).toBeUndefined()
+      expect(getModelAttribute({
+        attribute: { type: 'user' },
+        key: 'key',
+        data: {},
+        userId: userId.toString()
+      })).toEqual(userId)
+      expect(getModelAttribute({
+        attribute: { type: 'user' },
+        key: 'key',
+        data: {}
+      })).toBeUndefined()
     })
 
     it('should handle the required attribute', async () => {
-      expect(await getModelAttribute({ type: 'user', required: true }, 'key', {}, userId.toString()))
-        .toEqual(userId)
-      await expect(getModelAttribute({ type: 'user', required: true }, 'key', {}))
-        .rejects.toThrow('key is required')
+      expect(getModelAttribute({
+        attribute: { type: 'user', required: true },
+        key: 'key',
+        data: {},
+        userId: userId.toString()
+      })).toEqual(userId)
+      expect(() => getModelAttribute({
+        attribute: { type: 'user', required: true },
+        key: 'key',
+        data: {}
+      })).toThrow('key is required')
     })
 
     it('should handle the default attribute', async () => {
-      expect(await getModelAttribute({ type: 'user', default: userId.toString() }, 'key', {}))
-        .toEqual(userId)
-      expect(await getModelAttribute({
-        type: 'user',
-        default: new ObjectId().toString()
-      }, 'key', {}, userId.toString())).toEqual(userId)
+      expect(getModelAttribute({
+        attribute: { type: 'user', default: userId.toString() },
+        key: 'key',
+        data: {}
+      })).toEqual(userId)
+      expect(getModelAttribute({
+        attribute: {
+          type: 'user',
+          default: new ObjectId().toString()
+        },
+        key: 'key',
+        data: {},
+        userId: userId.toString()
+      })).toEqual(userId)
     })
   })
 })

--- a/packages/core/test/entity/modelAttributes.test.ts
+++ b/packages/core/test/entity/modelAttributes.test.ts
@@ -387,7 +387,7 @@ describe('modelAttributes', () => {
         entityName,
         attribute: { type: 'eval', eval: 'test' },
         key: 'key',
-        data: { key: 'test' }
+        data: {}
       })).toBe('test')
     })
 
@@ -396,13 +396,13 @@ describe('modelAttributes', () => {
         entityName,
         attribute: { type: 'eval', eval: 'Val: {2 + 2}' },
         key: 'key',
-        data: { key: 'test' }
+        data: {}
       })).toBe('Val: 4')
       expect(await getModelAttribute({
         entityName,
         attribute: { type: 'eval', eval: 'Val: {this.num * 2}' },
         key: 'key',
-        data: { key: 'test', num: 3 }
+        data: { key: null, num: 3 }
       })).toBe('Val: 6')
     })
 
@@ -411,13 +411,13 @@ describe('modelAttributes', () => {
         entityName,
         attribute: { type: 'eval', eval: '{this.foo}' },
         key: 'key',
-        data: { key: 'test', foo: 'bar' }
+        data: { key: null, foo: 'bar' }
       })).toBe('bar')
       expect(await getModelAttribute({
         entityName,
         attribute: { type: 'eval', eval: '{this.foo}:{this.bar}' },
         key: 'key',
-        data: { key: 'test', foo: '1', bar: '2' }
+        data: { key: null, foo: '1', bar: '2' }
       })).toBe('1:2')
     })
 

--- a/packages/dashboard/src/components/Forms/ModelAttributeForms/EvalModelAttributeForm.tsx
+++ b/packages/dashboard/src/components/Forms/ModelAttributeForms/EvalModelAttributeForm.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react'
+import { EvalModelAttribute } from '@commun/core'
+import { Grid, TextField } from '@material-ui/core'
+import { handleAttrChange } from '../../../utils/attributes'
+import { ModelAttributeSharedOptions } from './ModelAttributeSharedOptions'
+import { ModelAttributeAdvanceSharedOptions } from './ModelAttributeAdvanceSharedOptions'
+
+interface Props {
+  attribute: EvalModelAttribute
+  subAttribute: boolean
+  onChange: (key: keyof EvalModelAttribute, value: any) => void
+}
+
+export const EvalModelAttributeForm = (props: Props) => {
+  const { attribute, subAttribute, onChange } = props
+  const [evalValue, setEval] = useState(attribute.eval)
+
+  return (
+    <>
+      <Grid item xs={12}>
+        <TextField
+          onChange={e => handleAttrChange(onChange, 'eval', e.target.value as string, setEval)}
+          value={evalValue}
+          name="eval"
+          type="string"
+          variant="outlined"
+          margin="normal"
+          fullWidth
+          required
+          label="Eval"
+          helperText="Supports constants or expressions like {this.value + 3}"/>
+      </Grid>
+
+      <ModelAttributeSharedOptions attribute={attribute} subAttribute={subAttribute} onChange={onChange}/>
+      <ModelAttributeAdvanceSharedOptions attribute={attribute} subAttribute={subAttribute} onChange={onChange}/>
+    </>
+  )
+}

--- a/packages/dashboard/src/components/Forms/ModelAttributeForms/ModelAttributeFormSwitch.tsx
+++ b/packages/dashboard/src/components/Forms/ModelAttributeForms/ModelAttributeFormSwitch.tsx
@@ -9,6 +9,7 @@ import { StringModelAttributeForm } from './StringModelAttributeForm'
 import { ModelAttributeSharedOptions } from './ModelAttributeSharedOptions'
 import { ModelAttributeAdvanceSharedOptions } from './ModelAttributeAdvanceSharedOptions'
 import { MapModelAttributeForm } from './MapModelAttributeForm'
+import { EvalModelAttributeForm } from './EvalModelAttributeForm'
 
 interface Props {
   entity: EntityConfig<EntityModel>
@@ -30,6 +31,10 @@ export const ModelAttributeFormSwitch = (props: Props) => {
   switch (attribute.type) {
     case 'enum':
       return <EnumModelAttributeForm attribute={attribute}
+                                     subAttribute={subAttribute}
+                                     onChange={onChange}/>
+    case 'eval':
+      return <EvalModelAttributeForm attribute={attribute}
                                      subAttribute={subAttribute}
                                      onChange={onChange}/>
     case 'list':

--- a/packages/dashboard/src/components/Forms/Selectors/AttributeTypeSelector.tsx
+++ b/packages/dashboard/src/components/Forms/Selectors/AttributeTypeSelector.tsx
@@ -35,6 +35,7 @@ export const AttributeTypeSelector = (props: Props) => {
         <MenuItem value="date">Date</MenuItem>
         <MenuItem value="email">Email</MenuItem>
         <MenuItem value="enum">Enum</MenuItem>
+        <MenuItem value="eval">Eval</MenuItem>
         <MenuItem value="list">List</MenuItem>
         <MenuItem value="map">Map</MenuItem>
         <MenuItem value="number">Number</MenuItem>

--- a/packages/graphql/src/SchemaBuilder.ts
+++ b/packages/graphql/src/SchemaBuilder.ts
@@ -286,6 +286,7 @@ export function getAttributeGraphQLType (
     case 'boolean':
       return GraphQLBoolean
     case 'email':
+    case 'eval':
     case 'slug':
     case 'string':
       return GraphQLString

--- a/packages/users/src/controllers/BaseUserController.ts
+++ b/packages/users/src/controllers/BaseUserController.ts
@@ -107,8 +107,13 @@ export class BaseUserController<MODEL extends BaseUserModel> extends EntityContr
 
     const resetPasswordAttr = Commun.getEntityConfig<MODEL>(UserModule.entityName).attributes.resetPasswordCodeHash
     const plainResetPasswordCode = SecurityUtils.generateRandomString(48)
-    const resetPasswordCodeHash = await getModelAttribute(resetPasswordAttr!, 'resetPasswordCodeHash', {
-      resetPasswordCodeHash: plainResetPasswordCode
+    const resetPasswordCodeHash = await getModelAttribute({
+      entityName: this.entityName,
+      attribute: resetPasswordAttr!,
+      key: 'resetPasswordCodeHash',
+      data: {
+        resetPasswordCodeHash: plainResetPasswordCode
+      },
     })
     await this.dao.updateOne(user.id!, { resetPasswordCodeHash })
 
@@ -133,7 +138,12 @@ export class BaseUserController<MODEL extends BaseUserModel> extends EntityContr
 
     if (user.resetPasswordCodeHash && await SecurityUtils.bcryptHashIsValid(req.body.code, user.resetPasswordCodeHash)) {
       const passwordAttr = Commun.getEntityConfig<MODEL>(UserModule.entityName).attributes.password
-      const password = await getModelAttribute<MODEL>(passwordAttr!, 'password', { password: req.body.password })
+      const password = await getModelAttribute<MODEL>({
+        entityName: this.entityName,
+        attribute: passwordAttr!,
+        key: 'password',
+        data: { password: req.body.password },
+      })
       await this.dao.updateOne(user.id!, { password, resetPasswordCodeHash: undefined })
       return { result: true }
     }
@@ -241,8 +251,13 @@ export class BaseUserController<MODEL extends BaseUserModel> extends EntityContr
     if (UserModule.getOptions().refreshToken.enabled) {
       const refreshTokenAttr = Commun.getEntityConfig<MODEL>(UserModule.entityName).attributes.refreshTokenHash
       const plainRefreshToken = SecurityUtils.generateRandomString(48)
-      const refreshTokenHash = await getModelAttribute(refreshTokenAttr!, 'refreshTokenHash', {
-        refreshTokenHash: plainRefreshToken
+      const refreshTokenHash = await getModelAttribute({
+        entityName: this.entityName,
+        attribute: refreshTokenAttr!,
+        key: 'refreshTokenHash',
+        data: {
+          refreshTokenHash: plainRefreshToken
+        },
       })
       await this.dao.updateOne(user.id!, { refreshTokenHash })
       return plainRefreshToken


### PR DESCRIPTION
Eval attributes allow to create attributes derived from the value of other attributes.

### Examples:

#### Field karma with the addition of post karma and comment karma
```
"karma": {
  "type": "eval",
  "eval": "{this.postKarma + this.commentKarma}",
  "permissions": {
    "create": "system",
    "update": "system"
  }
}
```

#### User signature
```
"signature": {
  "type": "eval",
  "eval": "Created by {user.username}",
  "permissions": {
    "create": "system",
    "update": "system"
  }
}
```
