### PR TITLE
Fix GraphQL generation for objects with additionalProperties set to true

### DIFF
--- a/packages/graphql/package-lock.json
+++ b/packages/graphql/package-lock.json
@@ -79,12 +79,12 @@
 			}
 		},
 		"@types/graphql-fields": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@types/graphql-fields/-/graphql-fields-1.3.2.tgz",
-			"integrity": "sha512-f8GVo030fc4RVPB4f7x7YHdaVhgAhucrjvO6jSOOoBonwSGKW/OeVQ3zWCxBRMyoAedEmmUrEpbXuD2eb0UlIg==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@types/graphql-fields/-/graphql-fields-1.3.3.tgz",
+			"integrity": "sha512-rE54TMk0ozadGuUtmNvRgme/4QcwG0cl8GfcNbuFyB3whHKCrnuQp7YQZn9dELOdJang8KQx4kqPzM8uNHYNnA==",
 			"dev": true,
 			"requires": {
-				"graphql": "^14.5.3"
+				"graphql": "^15.3.0"
 			}
 		},
 		"@types/graphql-type-json": {
@@ -94,6 +94,17 @@
 			"dev": true,
 			"requires": {
 				"graphql": "^14.5.3"
+			},
+			"dependencies": {
+				"graphql": {
+					"version": "14.7.0",
+					"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+					"integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+					"dev": true,
+					"requires": {
+						"iterall": "^1.2.2"
+					}
+				}
 			}
 		},
 		"@types/json-schema": {
@@ -449,12 +460,9 @@
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"graphql": {
-			"version": "14.6.0",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
-			"integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
-			"requires": {
-				"iterall": "^1.2.2"
-			}
+			"version": "15.3.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+			"integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
 		},
 		"graphql-fields": {
 			"version": "2.0.3",
@@ -505,7 +513,8 @@
 		"iterall": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+			"dev": true
 		},
 		"media-typer": {
 			"version": "0.3.0",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -24,7 +24,7 @@
     "@commun/users": "^1.0.0",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
-    "graphql": "^14.6.0",
+    "graphql": "^15.3.0",
     "graphql-fields": "^2.0.3",
     "graphql-type-json": "^0.3.2"
   },
@@ -33,7 +33,7 @@
     "@types/express": "^4.17.2",
     "@types/express-graphql": "^0.9.0",
     "@types/graphql": "^14.5.0",
-    "@types/graphql-fields": "^1.3.2",
+    "@types/graphql-fields": "^1.3.3",
     "@types/graphql-type-json": "^0.3.2",
     "@types/json-schema": "^7.0.5",
     "@types/mongodb": "^3.3.14",

--- a/packages/graphql/src/SchemaBuilder.ts
+++ b/packages/graphql/src/SchemaBuilder.ts
@@ -128,7 +128,7 @@ function buildEntityObjectType (entityConfig: EntityConfig<EntityModel>): GraphQ
     return entityObjectTypesCache[entityConfig.entityName]
   }
 
-  const fields: Thunk<GraphQLFieldConfigMap<any, any, any>> = {}
+  const fields: Thunk<GraphQLFieldConfigMap<any, any>> = {}
 
   // create the GraphQL object and cache it before setting the fields, to support circular references
   entityObjectTypesCache[entityConfig.entityName] = new GraphQLObjectType({

--- a/packages/graphql/test/controllers/GraphQLController.test.ts
+++ b/packages/graphql/test/controllers/GraphQLController.test.ts
@@ -14,6 +14,7 @@ describe('GraphQLController', () => {
     subEntities?: {
       entity: string
     }[]
+    object?: object
   }
 
   interface SubEntity extends EntityModel {
@@ -56,6 +57,10 @@ describe('GraphQLController', () => {
                   },
                 },
               },
+            },
+            object: {
+              type: 'object',
+              additionalProperties: true,
             },
           },
         },
@@ -573,6 +578,24 @@ describe('GraphQLController', () => {
              }`
         })
         .expect(200)
+      expect(res.body.errors).not.toBeDefined()
+    })
+
+    it('should support objects with additionalProperties', async () => {
+      const node = await getDao().insertOne({ name: 'test', object: { foo: 'bar', test: true, } })
+      const res = await request()
+        .post('/graphql')
+        .send({
+          query:
+            `{
+               item (id: "${node.id}") {
+                 name
+                 object
+               }
+             }`
+        })
+        .expect(200)
+      expect(res.body.data.item).toEqual({ name: 'test', object: { foo: 'bar', test: true, } })
       expect(res.body.errors).not.toBeDefined()
     })
   })


### PR DESCRIPTION
Update graphql version in order to fix an issue with objects that depend on `GraphQLJSONObject`:

```
Error: Cannot use GraphQLScalarType "JSONObject" from another module or realm.

Ensure that there is only one instance of "graphql" in the node_modules
directory. If different versions of "graphql" are the dependencies of other
relied on modules, use "resolutions" to ensure only one version is installed.

https://yarnpkg.com/en/docs/selective-version-resolutions

Duplicate "graphql" modules cannot be used at the same time since different
versions may have different capabilities and behavior. The data from one
version used in the function from another could produce confusing and
spurious results.
    at instanceOf (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/node_modules/graphql/jsutils/instanceOf.js:28:13)
    at isScalarType (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/node_modules/graphql/type/definition.js:103:34)
    at isType (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/node_modules/graphql/type/definition.js:86:10)
    at isNullableType (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/node_modules/graphql/type/definition.js:380:10)
    at assertNullableType (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/node_modules/graphql/type/definition.js:384:8)
    at new GraphQLNonNull (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/node_modules/graphql/type/definition.js:345:19)
    at buildFilterEntityInputType (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/lib/SchemaBuilder.js:197:31)
    at Object.createGraphQLSchema (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/lib/SchemaBuilder.js:73:37)
    at Object.<anonymous> (/Users/marian2js/workspace/flow/backend/node_modules/@commun/graphql/lib/GraphQLModule.js:37:44)
    at Generator.next (<anonymous>)
```

Properties with `additionalProperties` set to true can accept any property, so in the GraphQL Schema they need to be mapped to a generic JSON.