### PR TITLE
Fix issue with email template variables containing white spaces

### DIFF
--- a/packages/emails/src/EmailClient.ts
+++ b/packages/emails/src/EmailClient.ts
@@ -40,7 +40,7 @@ export const EmailClient = {
 
 function parseTemplateVariables (template: string, variables: TemplateVariables) {
   for (const [key, value] of Object.entries(variables)) {
-    const regexp = RegExp(`{\s*${key}\s*}`, 'g')
+    const regexp = RegExp(`{\\s*${key}\\s*}`, 'g')
     template = template.replace(regexp, (value || '').toString())
   }
   return template


### PR DESCRIPTION
Fix RegExp issue find by CodeQL:

```
The escape sequence '\s' is equivalent to just 's', so the sequence is not a character class when it is used in a regular expression.
```

[CodeQL Query](https://github.com/github/codeql/blob/master/javascript/ql/src/Security/CWE-020/UselessRegExpCharacterEscape.ql)